### PR TITLE
fix: Remove debug stuff

### DIFF
--- a/internal/log.go
+++ b/internal/log.go
@@ -6,12 +6,12 @@ import (
 )
 
 func PrepareLogger() (*os.File, error) {
-	// logFile, err := os.OpenFile("sisr-remote-helper.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	logFile, err := os.OpenFile("sisr-remote-helper.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		return nil, err
+	}
 
-	logFile := os.Stdout
+	// logFile := os.Stdout
 
 	logger := slog.New(slog.NewTextHandler(logFile, &slog.HandlerOptions{
 		Level: slog.LevelDebug,

--- a/script/build
+++ b/script/build
@@ -17,9 +17,9 @@ NAME=$(cat package.json | jq --raw-output .name)
 for os in "${OSES[@]}"; do
   for arch in "${ARCHS[@]}"; do
     LDFLAGS="-s -w"
-    # if [[ "$os" == "windows" ]]; then
-    #   LDFLAGS="$LDFLAGS -H=windowsgui"
-    # fi
+    if [[ "$os" == "windows" ]]; then
+      LDFLAGS="$LDFLAGS -H=windowsgui"
+    fi
 
     GOOS="$os" GOARCH="$arch" go build -ldflags "$LDFLAGS" -o "dist/$NAME-$os-$arch" ./cmd/sisr-remote-helper.go
   done


### PR DESCRIPTION
On proper builds there won't be a console, but it's much easier to test when you don't have to `cat` / `tail` a log file.